### PR TITLE
Correction deuxième jour de Noël (Saint-Etienne)

### DIFF
--- a/jours_feries_france/__init__.py
+++ b/jours_feries_france/__init__.py
@@ -100,7 +100,7 @@ class JoursFeries(object):
 
     @staticmethod
     def vendredi_saint(year, zone):
-        if zone == JoursFeries.check_zone("Alsace-Moselle"):
+        if zone == JoursFeries.check_zone("Alsace-Moselle") an year >= 1892:
             return JoursFeries.paques(year) - timedelta(days=2)
         return None
 

--- a/jours_feries_france/__init__.py
+++ b/jours_feries_france/__init__.py
@@ -166,7 +166,7 @@ class JoursFeries(object):
 
     @staticmethod
     def deuxieme_jour_noel(year, zone):
-        if zone == JoursFeries.check_zone("Alsace-Moselle"):
+        if zone == JoursFeries.check_zone("Alsace-Moselle") and year >= 1892:
             return date(year, 12, 26)
         return None
 

--- a/jours_feries_france/__init__.py
+++ b/jours_feries_france/__init__.py
@@ -100,7 +100,7 @@ class JoursFeries(object):
 
     @staticmethod
     def vendredi_saint(year, zone):
-        if zone == JoursFeries.check_zone("Alsace-Moselle") an year >= 1892:
+        if zone == JoursFeries.check_zone("Alsace-Moselle") and year >= 1892:
             return JoursFeries.paques(year) - timedelta(days=2)
         return None
 


### PR DESCRIPTION
Ce jour férié aurait été introduit en 1892 (une source parmi d'autres : https://www.senat.fr/questions/base/2007/qSEQ070801552.html)